### PR TITLE
Accept Reviewer changes

### DIFF
--- a/contracts/token/TalentirTokenV0.sol
+++ b/contracts/token/TalentirTokenV0.sol
@@ -17,6 +17,8 @@ contract TalentirTokenV0 is ERC1155(""), ERC2981, Ownable, Pausable {
 
     // - EVENTS
     event MarketplaceApproved(address marketplaceAddress, bool approved);
+    event RoyaltyPercentageChanged(uint256 percent);
+    event TalentChanged(address from, address to, uint256 tokenID);
 
     // - ADMIN FUNCTIONS
     // At the beginning, these are centralized with Talentir but should be handled by the
@@ -39,8 +41,9 @@ contract TalentirTokenV0 is ERC1155(""), ERC2981, Ownable, Pausable {
      * @notice Changing the royalty percentage of every sale. 1% = 1_000
      */
     function setRoyalty(uint256 percent) public onlyOwner {
-        require(percent <= 100_000, "Must be <= 100%");
-        _setRoyaltyPercent(percent);
+        require(percent <= 10_000, "Must be <= 10%");
+        _royaltyPercent = percent;
+        emit RoyaltyPercentageChanged(percent);
     }
 
     function setMinterRole(address minterAddress) public onlyOwner {
@@ -51,7 +54,7 @@ contract TalentirTokenV0 is ERC1155(""), ERC2981, Ownable, Pausable {
      * @notice Approve a new Marketplace Contract so users need less gas when selling and buying NFTs
      * on the Talentir contract.
      */
-    function setNftMarketplaceApproval(address marketplace, bool approval) public onlyOwner {
+    function approveNftMarketplace(address marketplace, bool approval) public onlyOwner {
         approvedMarketplaces[marketplace] = approval;
         emit MarketplaceApproved(marketplace, approval);
     }
@@ -80,18 +83,23 @@ contract TalentirTokenV0 is ERC1155(""), ERC2981, Ownable, Pausable {
         _mint(to, tokenId, TOKEN_FRACTIONS, "");
     }
 
-    /**
-     * @notice Burn a token. This is only possible for the owner of the token.
-     */
-    function burn(address account, uint256 tokenID, uint256 value) public virtual onlyOwner {
-        _burn(account, tokenID, value);
-    }
-
     function uri(uint256 tokenId) public view override returns (string memory) {
         return string(abi.encodePacked("ipfs://", _tokenCIDs[tokenId]));
     }
 
     // - PUBLIC FUNCTIONS
+
+    function updateTalent(uint256 tokenId, address talent) public {
+        address currentReceiver = _talents[tokenId];
+        require(currentReceiver == msg.sender, "Royalty receiver must update");
+        _setTalent(tokenId, talent);
+    }
+
+    function _setTalent(uint256 tokenID, address talent) internal {
+        address from = _talents[tokenID];
+        _talents[tokenID] = talent;
+        emit TalentChanged(from, talent, tokenID);
+    }
 
     /**
      * @notice A pure function to calculate the tokenID from a given unique contentID. A contentID

--- a/contracts/token/TalentirTokenV0.sol
+++ b/contracts/token/TalentirTokenV0.sol
@@ -13,6 +13,7 @@ contract TalentirTokenV0 is ERC1155(""), ERC2981, Ownable, Pausable {
     mapping(address => bool) public approvedMarketplaces;
     mapping(uint256 => string) private _tokenCIDs; // storing the IPFS CIDs
     address private _minterAddress;
+    uint256 public constant TOKEN_FRACTIONS = 1_000_000;
 
     // - EVENTS
     event MarketplaceApproved(address marketplaceAddress, bool approved);
@@ -74,9 +75,9 @@ contract TalentirTokenV0 is ERC1155(""), ERC2981, Ownable, Pausable {
     ) public onlyMinter {
         uint256 tokenId = contentIdToTokenId(contentID);
         require(bytes(_tokenCIDs[tokenId]).length == 0, "Token already minted");
-        _mint(to, tokenId, 1000000, "");
         _tokenCIDs[tokenId] = cid;
         _setTalent(tokenId, royaltyReceiver);
+        _mint(to, tokenId, TOKEN_FRACTIONS, "");
     }
 
     /**
@@ -110,11 +111,14 @@ contract TalentirTokenV0 is ERC1155(""), ERC2981, Ownable, Pausable {
         return approvedMarketplaces[operator] == true || super.isApprovedForAll(owner, operator);
     }
 
-    function batchTransfer (address from, address[] memory to, uint256 id, uint256[] memory amounts, bytes memory data) public {
-        require(
-            from == _msgSender() || isApprovedForAll(from, _msgSender()),
-            "Caller is not token owner or approved"
-        );
+    function batchTransfer(
+        address from,
+        address[] memory to,
+        uint256 id,
+        uint256[] memory amounts,
+        bytes memory data
+    ) public {
+        require(from == _msgSender() || isApprovedForAll(from, _msgSender()), "Caller is not token owner or approved");
         require(to.length == amounts.length, "Invalid array length");
 
         for (uint i = 0; i < to.length; i++) {

--- a/contracts/utils/ERC2981.sol
+++ b/contracts/utils/ERC2981.sol
@@ -8,6 +8,7 @@ import "@openzeppelin/contracts/interfaces/IERC2981.sol";
 contract ERC2981 is ERC165, IERC2981 {
     mapping(uint256 => address) internal _talents;
     uint256 private _royaltyPercent = 10_000;
+    uint256 internal constant PERCENT = 100_000;
 
     // - EVENTS
     event RoyaltyPercentageChanged(uint256 percent);
@@ -20,7 +21,7 @@ contract ERC2981 is ERC165, IERC2981 {
     ) public view override returns (address receiver, uint256 royaltyAmount) {
         require(_talents[tokenId] != address(0), "No royalty info for address");
         receiver = _talents[tokenId];
-        royaltyAmount = (value * _royaltyPercent) / 100_000;
+        royaltyAmount = (value * _royaltyPercent) / PERCENT;
     }
 
     function updateTalent(uint256 tokenId, address talent) public {

--- a/contracts/utils/ERC2981.sol
+++ b/contracts/utils/ERC2981.sol
@@ -7,13 +7,10 @@ import "@openzeppelin/contracts/interfaces/IERC2981.sol";
 /// @custom:security-contact security@talentir.com
 contract ERC2981 is ERC165, IERC2981 {
     mapping(uint256 => address) internal _talents;
-    uint256 private _royaltyPercent = 10_000;
+    uint256 internal _royaltyPercent = 7_500;
     uint256 internal constant PERCENT = 100_000;
 
     // - EVENTS
-    event RoyaltyPercentageChanged(uint256 percent);
-
-    event TalentChanged(address from, address to, uint256 tokenID);
 
     function royaltyInfo(
         uint256 tokenId,
@@ -24,24 +21,7 @@ contract ERC2981 is ERC165, IERC2981 {
         royaltyAmount = (value * _royaltyPercent) / PERCENT;
     }
 
-    function updateTalent(uint256 tokenId, address talent) public {
-        address currentReceiver = _talents[tokenId];
-        require(currentReceiver == msg.sender, "Royalty receiver must update");
-        _setTalent(tokenId, talent);
-    }
-
     function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165, IERC165) returns (bool) {
         return interfaceId == type(IERC2981).interfaceId || super.supportsInterface(interfaceId);
-    }
-
-    function _setTalent(uint256 tokenID, address talent) internal {
-        address from = _talents[tokenID];
-        _talents[tokenID] = talent;
-        emit TalentChanged(from, talent, tokenID);
-    }
-
-    function _setRoyaltyPercent(uint256 percent) internal {
-        emit RoyaltyPercentageChanged(percent);
-        _royaltyPercent = percent;
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "dotenv": "^16.0.3",
         "ethereum-waffle": "^3.4.4",
         "ethers": "^5.7.2",
-        "hardhat": "^2.12.3",
+        "hardhat": "^2.12.7",
         "hardhat-gas-reporter": "^1.0.9",
         "husky": "^8.0.2",
         "prettier": "^2.8.0",
@@ -15943,9 +15943,9 @@
       }
     },
     "node_modules/hardhat": {
-      "version": "2.12.3",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.12.3.tgz",
-      "integrity": "sha512-qxOvRNgQnLqRFssn5f8VP5KN3caytShU0HNeKxmPVK1Ix/0xDVhIC7JOLxG69DjOihUfmxmjqspsHbZvFj6EhQ==",
+      "version": "2.12.7",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.12.7.tgz",
+      "integrity": "sha512-voWoN6zn5d8BOEaczSyK/1PyfdeOeI3SbGCFb36yCHTJUt6OIqLb+ZDX30VhA1UsYKzLqG7UnWl3fKJUuANc6A==",
       "dependencies": {
         "@ethersproject/abi": "^5.1.2",
         "@metamask/eth-sig-util": "^4.0.0",
@@ -15994,7 +15994,7 @@
         "source-map-support": "^0.5.13",
         "stacktrace-parser": "^0.1.10",
         "tsort": "0.0.1",
-        "undici": "^5.4.0",
+        "undici": "^5.14.0",
         "uuid": "^8.3.2",
         "ws": "^7.4.6"
       },
@@ -22026,9 +22026,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.13.0.tgz",
-      "integrity": "sha512-UDZKtwb2k7KRsK4SdXWG7ErXiL7yTGgLWvk2AXO1JMjgjh404nFo6tWSCM2xMpJwMPx3J8i/vfqEh1zOqvj82Q==",
+      "version": "5.19.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.19.1.tgz",
+      "integrity": "sha512-YiZ61LPIgY73E7syxCDxxa3LV2yl3sN8spnIuTct60boiiRaE1J8mNWHO8Im2Zi/sFrPusjLlmRPrsyraSqX6A==",
       "dependencies": {
         "busboy": "^1.6.0"
       },
@@ -34561,9 +34561,9 @@
       }
     },
     "hardhat": {
-      "version": "2.12.3",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.12.3.tgz",
-      "integrity": "sha512-qxOvRNgQnLqRFssn5f8VP5KN3caytShU0HNeKxmPVK1Ix/0xDVhIC7JOLxG69DjOihUfmxmjqspsHbZvFj6EhQ==",
+      "version": "2.12.7",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.12.7.tgz",
+      "integrity": "sha512-voWoN6zn5d8BOEaczSyK/1PyfdeOeI3SbGCFb36yCHTJUt6OIqLb+ZDX30VhA1UsYKzLqG7UnWl3fKJUuANc6A==",
       "requires": {
         "@ethersproject/abi": "^5.1.2",
         "@metamask/eth-sig-util": "^4.0.0",
@@ -34612,7 +34612,7 @@
         "source-map-support": "^0.5.13",
         "stacktrace-parser": "^0.1.10",
         "tsort": "0.0.1",
-        "undici": "^5.4.0",
+        "undici": "^5.14.0",
         "uuid": "^8.3.2",
         "ws": "^7.4.6"
       },
@@ -39150,9 +39150,9 @@
       }
     },
     "undici": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.13.0.tgz",
-      "integrity": "sha512-UDZKtwb2k7KRsK4SdXWG7ErXiL7yTGgLWvk2AXO1JMjgjh404nFo6tWSCM2xMpJwMPx3J8i/vfqEh1zOqvj82Q==",
+      "version": "5.19.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.19.1.tgz",
+      "integrity": "sha512-YiZ61LPIgY73E7syxCDxxa3LV2yl3sN8spnIuTct60boiiRaE1J8mNWHO8Im2Zi/sFrPusjLlmRPrsyraSqX6A==",
       "requires": {
         "busboy": "^1.6.0"
       }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dotenv": "^16.0.3",
     "ethereum-waffle": "^3.4.4",
     "ethers": "^5.7.2",
-    "hardhat": "^2.12.3",
+    "hardhat": "^2.12.7",
     "hardhat-gas-reporter": "^1.0.9",
     "husky": "^8.0.2",
     "prettier": "^2.8.0",

--- a/scripts/interact.ts
+++ b/scripts/interact.ts
@@ -12,7 +12,7 @@ async function main (): Promise<void> {
   const talentirMarketplaceFactory = new TalentirMarketplaceV0__factory(signer[0])
   const talentirMarketplace = talentirMarketplaceFactory.attach(marketplaceAddress)
 
-  const tx1 = await talentirNFT.setNftMarketplaceApproval(marketplaceAddress, true)
+  const tx1 = await talentirNFT.approveNftMarketplace(marketplaceAddress, true)
   console.log('TalentirNFT: Approved marketplace: ', marketplaceAddress, ' tx:', tx1.hash)
 
   // Grant the Openzeppelin Relay the Minter Role

--- a/test/marketplace-test.ts
+++ b/test/marketplace-test.ts
@@ -65,7 +65,7 @@ describe('Marketplace Tests', function () {
     ).to.be.revertedWith('ERC1155: caller is not token owner or approved')
     // Grant allowance and make sell order
     await expect(
-      talentirNFT.setNftMarketplaceApproval(marketplace.address, true)
+      talentirNFT.approveNftMarketplace(marketplace.address, true)
     ).to.emit(talentirNFT, 'MarketplaceApproved')
     // Can't add orders with 0 quantity or price
     await expect(
@@ -208,7 +208,7 @@ describe('Marketplace Tests', function () {
   it('should distribute fees correctly', async function () {
     // Grant marketplace approval
     await expect(
-      talentirNFT.setNftMarketplaceApproval(marketplace.address, true)
+      talentirNFT.approveNftMarketplace(marketplace.address, true)
     ).to.emit(talentirNFT, 'MarketplaceApproved')
     // Mint token to seller
     await talentirNFT.mint(
@@ -290,7 +290,7 @@ describe('Marketplace Tests', function () {
     )
     // Grant allowance
     await expect(
-      talentirNFT.setNftMarketplaceApproval(marketplace.address, true)
+      talentirNFT.approveNftMarketplace(marketplace.address, true)
     ).to.emit(talentirNFT, 'MarketplaceApproved')
     // Add multiple buy and sell orders
     for (let i = 5; i <= 10; i++) {
@@ -425,7 +425,7 @@ describe('Marketplace Tests', function () {
       1000000
     )
     await expect(
-      talentirNFT.setNftMarketplaceApproval(marketplace.address, true)
+      talentirNFT.approveNftMarketplace(marketplace.address, true)
     ).to.emit(talentirNFT, 'MarketplaceApproved')
     await expect(marketplace.makeSellOrder(tokenId, oneEther, 1, true)).to.emit(
       marketplace,

--- a/test/marketplace-test.ts
+++ b/test/marketplace-test.ts
@@ -57,7 +57,7 @@ describe('Marketplace Tests', function () {
     )
     const tokenId = await talentirNFT.contentIdToTokenId('abc')
     expect(await talentirNFT.balanceOf(seller.address, tokenId)).to.equal(
-      1000000
+      1_000_000
     )
     // Still can't make sell order because of missing allowance
     await expect(
@@ -107,7 +107,7 @@ describe('Marketplace Tests', function () {
     expect(order.quantity).to.equal(1)
     // Balances are updated
     expect(await talentirNFT.balanceOf(seller.address, tokenId)).to.equal(
-      999999
+      999_999
     )
     expect(await talentirNFT.balanceOf(marketplace.address, tokenId)).to.equal(
       1

--- a/test/nft-test.ts
+++ b/test/nft-test.ts
@@ -52,7 +52,7 @@ describe('TalentirNFT', function () {
     await talentir.setMinterRole(minter.address)
   });
 
-  it('mints and burns', async function () {
+  it('mints', async function () {
     const cid1 = 'QmPxtVYgecSPTrnkZxjP3943ue3uizWtywzH7U9QwkLHU1'
     const contentID1 = '1'
     const tokenID1 = await talentir.contentIdToTokenId(contentID1)
@@ -70,15 +70,6 @@ describe('TalentirNFT', function () {
         .connect(minter)
         .mint(luki.address, cid1, contentID1, luki.address)
     ).to.be.revertedWith('Token already minted')
-
-    await expect(
-      talentir.connect(luki).burn(luki.address, tokenID1, 1000)
-    ).to.be.revertedWith('Ownable: caller is not the owner')
-
-    await talentir.burn(luki.address, tokenID1, 1000)
-
-    const balance2 = await talentir.balanceOf(luki.address, tokenID1)
-    expect(balance2).to.equal(999_000)
   })
 
   it('can approve a marketplace to transfer tokens', async function () {
@@ -98,10 +89,10 @@ describe('TalentirNFT', function () {
     ).to.be.revertedWith('ERC1155: caller is not token owner or approved')
 
     await expect(
-      talentir.connect(luki).setNftMarketplaceApproval(johnny.address, true)
+      talentir.connect(luki).approveNftMarketplace(johnny.address, true)
     ).to.be.revertedWith('Ownable: caller is not the owner')
 
-    await talentir.setNftMarketplaceApproval(johnny.address, true)
+    await talentir.approveNftMarketplace(johnny.address, true)
 
     await talentir
       .connect(johnny)
@@ -149,9 +140,9 @@ describe('TalentirNFT', function () {
       .to.emit(talentir, 'TalentChanged')
       .withArgs(ethers.constants.AddressZero, johnny.address, tokenID1)
 
-    const result = await talentir.royaltyInfo(tokenID1, 100)
+    const result = await talentir.royaltyInfo(tokenID1, 1000)
     expect(result[0]).to.equal(johnny.address)
-    expect(result[1]).to.equal(10)
+    expect(result[1]).to.equal(75)
 
     // // Fail for non-existing royalty info
     await expect(talentir.connect(luki).royaltyInfo(1, 100)).to.be.reverted
@@ -159,15 +150,15 @@ describe('TalentirNFT', function () {
     await expect(
       talentir.connect(minter).setRoyalty(15_000)
     ).to.be.revertedWith('Ownable: caller is not the owner')
-    await expect(talentir.setRoyalty(101_000)).to.be.revertedWith(
-      'Must be <= 100%'
+    await expect(talentir.setRoyalty(10_001)).to.be.revertedWith(
+      'Must be <= 10%'
     )
 
-    await talentir.setRoyalty(15_000)
+    await talentir.setRoyalty(10_000)
 
     const result2 = await talentir.royaltyInfo(tokenID1, 100)
     expect(result2[0]).to.equal(johnny.address)
-    expect(result2[1]).to.equal(15)
+    expect(result2[1]).to.equal(10)
 
     await expect(talentir.updateTalent(tokenID1, luki.address)).to.be.reverted
     await expect(talentir.connect(luki).updateTalent(tokenID1, luki.address)).to
@@ -210,11 +201,6 @@ describe('TalentirNFT', function () {
         .connect(johnny)
         .safeTransferFrom(johnny.address, luki.address, tokenID1, 1, '0x')
     ).to.be.revertedWith('Pausable: paused')
-
-    //   // Burn should fail
-    await expect(talentir.burn(johnny.address, tokenID1, 1)).to.be.revertedWith(
-      'Pausable: paused'
-    )
 
     await talentir.unpause()
 

--- a/test/nft-test.ts
+++ b/test/nft-test.ts
@@ -38,10 +38,9 @@ describe('TalentirNFT', function () {
     expect(uri).to.equal(`ipfs://${cid1}`)
   })
 
-  it('Test Minting / Burning', async function () {
+  it('disallows interactions from unpermitted accounts', async function () {
     const cid1 = 'QmPxtVYgecSPTrnkZxjP3943ue3uizWtywzH7U9QwkLHU1'
     const contentID1 = '1'
-    const tokenID1 = await talentir.contentIdToTokenId(contentID1)
 
     await expect(
       talentir.mint(luki.address, cid1, contentID1, luki.address)
@@ -51,7 +50,12 @@ describe('TalentirNFT', function () {
       talentir.connect(luki).setMinterRole(minter.address)
     ).to.be.revertedWith('Ownable: caller is not the owner')
     await talentir.setMinterRole(minter.address)
+  });
 
+  it('mints and burns', async function () {
+    const cid1 = 'QmPxtVYgecSPTrnkZxjP3943ue3uizWtywzH7U9QwkLHU1'
+    const contentID1 = '1'
+    const tokenID1 = await talentir.contentIdToTokenId(contentID1)
     await expect(
       talentir
         .connect(minter)
@@ -59,7 +63,7 @@ describe('TalentirNFT', function () {
     ).to.emit(talentir, 'TransferSingle')
 
     const balance = await talentir.balanceOf(luki.address, tokenID1)
-    expect(balance).to.equal(1000000)
+    expect(balance).to.equal(1_000_000)
 
     await expect(
       talentir
@@ -74,10 +78,10 @@ describe('TalentirNFT', function () {
     await talentir.burn(luki.address, tokenID1, 1000)
 
     const balance2 = await talentir.balanceOf(luki.address, tokenID1)
-    expect(balance2).to.equal(999000)
+    expect(balance2).to.equal(999_000)
   })
 
-  it('Marketplace address', async function () {
+  it('can approve a marketplace to transfer tokens', async function () {
     const cid1 = 'QmPxtVYgecSPTrnkZxjP3943ue3uizWtywzH7U9QwkLHU1'
     const contentID1 = '1'
     const tokenID1 = await talentir.contentIdToTokenId(contentID1)
@@ -107,7 +111,7 @@ describe('TalentirNFT', function () {
     expect(balance).to.equal(1)
   })
 
-  it('Approval', async function () {
+  it('can approve an account to transfer tokens', async function () {
     const cid1 = 'QmPxtVYgecSPTrnkZxjP3943ue3uizWtywzH7U9QwkLHU1'
     const contentID1 = '1'
     const tokenID1 = await talentir.contentIdToTokenId(contentID1)


### PR DESCRIPTION
### Suggestions deliberately ignored

- Marketplace: Use OpenZeppelin Address library to send Ether. Reason: we use the same pattern anyway, but we don't want to revert in case of a failed receipt

- Pull Payments: we decided we don't want that pattern

### Suggestions not yet implemented, to discuss

- Run Slither

- Marketplace: pass more parameters to executeOrder

- Why is the Talentir-Token-Logic split between the ERC2981 implementation and the Token contract? Also, there seems to be lots of duplicate logic (_setRoyaltyPercent is only called by setRoyalty eg)

- Shouldn't we have a more reasonable upper limit for the Royalty %, eg 10% (right now 100%)?

- Rename setNftMarketplaceApproval to approveNftMarketplace

- burn is callable by contract owner, not token owner - I suggest we should change this to token owner?

- why is the royalty set to 10% by default?